### PR TITLE
Move illuminate package to dev only, allow PHP 8+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
     "type": "library",
     "require": {
         "slim/slim": "^4.10",
-        "illuminate/database": "^8.83",
-        "php": "^7.4",
+        "php": "^7.4 || ^8.0",
         "slim/php-view": "^3.1",
         "monolog/monolog": "^2.4",
         "ramsey/uuid": "^4.2",
@@ -36,6 +35,7 @@
         }
     ],
     "require-dev": {
+        "illuminate/database": "^8.83",
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.6"
     },


### PR DESCRIPTION
- Illuminate package is only use for tests
- Allow PHP 8.*